### PR TITLE
Adding support for optional secrets.

### DIFF
--- a/tests/charts/v1beta2/chart5/platz/values-ui.yaml
+++ b/tests/charts/v1beta2/chart5/platz/values-ui.yaml
@@ -41,9 +41,6 @@ inputs:
             - 0
             - 1
           - "a"
-  - id: conditional_text
-    type: text
-    label: Required text
 outputs:
   values:
     - path:

--- a/tests/charts/v1beta2/chart6/Chart.yaml
+++ b/tests/charts/v1beta2/chart6/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: Test chart
+version: 1.0.0

--- a/tests/charts/v1beta2/chart6/platz/values-ui.yaml
+++ b/tests/charts/v1beta2/chart6/platz/values-ui.yaml
@@ -1,0 +1,47 @@
+apiVersion: platz.io/v1beta1
+kind: ValuesUi
+inputs:
+  - id: required_bool
+    type: Checkbox
+    label: Required bool
+    initialValue: true
+    required: true    
+  - id: conditional_select
+    type: CollectionSelect
+    label: Optional select, shown if required bool is checked
+    collection: First
+    required: true
+    showIf: { "===": [var: required_bool, true] }
+  - id: conditional_text
+    type: text
+    label: Conditional text, shown if required bool is checked
+    required: true
+    showIf: { "===": [var: required_bool, true] }
+outputs:
+  values:
+    - path:
+        - config
+        - selected
+        - id
+      value:
+        FieldProperty: 
+          input: conditional_select
+          property: id
+    - path:
+        - config
+        - selected
+        - a
+      value:
+        FieldProperty: 
+          input: conditional_select
+          property: a
+  secrets:
+    secret-env:
+      SELECTED_SECRET:
+        FieldProperty:
+          input: conditional_select
+          property: a
+      TYPED_SECRET:
+        FieldValue:
+          input: conditional_text
+          


### PR DESCRIPTION
A key will not be created if source input is optional and missing, and a whole secret won't be created if all it's keys were not created. Missing mandatory fields would still cause an error.