### PR TITLE
Add CI workflow to run clippy and tests on all PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,8 +1,0 @@
-name: CI
-
-on:
-  pull_request:
-
-jobs:
-  test:
-    uses: ./.github/workflows/test.yml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    name: 🧪 Test and Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛠 Checkout
+        uses: actions/checkout@v4
+
+      - name: 📦 Cargo clippy (default features)
+        run: |
+          cargo clippy -- -D warnings
+
+      - name: 📦 Cargo clippy (all features)
+        run: |
+          cargo clippy --all-features -- -D warnings
+
+      - name: 🧪 Cargo test (default features)
+        run: |
+          cargo test
+
+      - name: 🧪 Cargo test (all features)
+        run: |
+          cargo test --all-features

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,24 +5,4 @@ on:
 
 jobs:
   test:
-    name: 🧪 Test and Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🛠 Checkout
-        uses: actions/checkout@v4
-
-      - name: 📦 Cargo clippy (default features)
-        run: |
-          cargo clippy -- -D warnings
-
-      - name: 📦 Cargo clippy (all features)
-        run: |
-          cargo clippy --all-features -- -D warnings
-
-      - name: 🧪 Cargo test (default features)
-        run: |
-          cargo test
-
-      - name: 🧪 Cargo test (all features)
-        run: |
-          cargo test --all-features
+    uses: ./.github/workflows/test.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish to crates.io
+name: 🚀 Publish to crates.io
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,28 +6,16 @@ on:
       - v**
 
 jobs:
-  build:
+  test:
+    uses: ./.github/workflows/test.yml
+
+  publish:
     name: 🚀 Publish to crates.io
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: 🛠 Checkout
         uses: actions/checkout@v4
-
-      - name: 📦 Cargo clippy (default features)
-        run: |
-          cargo clippy -- -D warnings
-
-      - name: 📦 Cargo clippy (all features)
-        run: |
-          cargo clippy --all-features -- -D warnings
-
-      - name: 📦 Cargo build (default features)
-        run: |
-          cargo build --release
-
-      - name: 📦 Cargo build (all features)
-        run: |
-          cargo build --release --all-features
 
       - name: 🚀 Publish Crate
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test and Lint
+name: 🧪 Test
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    name: 🧪 Test and Lint (${{ matrix.profile }})
+    name: 🧪 Test (${{ matrix.profile }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,14 @@ on:
 
 jobs:
   test:
-    name: 🧪 Test and Lint
+    name: 🧪 Test and Lint (${{ matrix.profile }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile:
+          - debug
+          - release
     steps:
       - name: 🛠 Checkout
         uses: actions/checkout@v4
@@ -18,8 +24,8 @@ jobs:
 
       - name: 📦 Cargo clippy (feature powerset)
         run: |
-          cargo hack clippy --feature-powerset -- -D warnings
+          cargo hack clippy --feature-powerset ${{ matrix.profile == 'release' && '--release' || '' }} -- -D warnings
 
       - name: 🧪 Cargo test (feature powerset)
         run: |
-          cargo hack test --feature-powerset
+          cargo hack test --feature-powerset ${{ matrix.profile == 'release' && '--release' || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test and Lint
 
 on:
+  pull_request:
   workflow_call:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test and Lint
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: 🧪 Test and Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛠 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🔧 Install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: 📦 Cargo clippy (feature powerset)
+        run: |
+          cargo hack clippy --feature-powerset -- -D warnings
+
+      - name: 🧪 Cargo test (feature powerset)
+        run: |
+          cargo hack test --feature-powerset

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -1,7 +1,0 @@
-#[cfg(feature = "utoipa")]
-#[test]
-fn test_openapi() {
-    use utoipa::OpenApi;
-    let openapi = platz_chart_ext::openapi::OpenApi::openapi();
-    println!("{}", openapi.to_json().unwrap());
-}


### PR DESCRIPTION
Also remove the orphaned tests/openapi.rs, which referenced the
openapi module deleted in 9f64cc1 and broke `cargo test --all-features`.

https://claude.ai/code/session_01BzqC31UjuAPBM2H7hfzdju