### PR TITLE
Harden CI workflows: permissions, warnings-as-errors, parallel matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v**
 
+permissions:
+  contents: read
+
 jobs:
   test:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: 🧪 Test (${{ matrix.profile }})


### PR DESCRIPTION
## Summary
- Set top-level `permissions: contents: read` on `test.yml` and `release.yml` so `GITHUB_TOKEN` is locked down to what `actions/checkout` actually needs (resolves the CodeQL findings from #12).
- Set `RUSTFLAGS=-D warnings` in the test workflow so any rustc or clippy warning fails CI. With that, the explicit `-- -D warnings` clippy suffix is no longer needed.
- Expand the test matrix to `{profile} x {task}` so clippy and test runs execute as 4 parallel jobs instead of serializing within one.
- Drop unused `mod fake_db;` from `tests/v1beta{1,2}_values_bad.rs` — the dead_code warnings on `TestDb`/`TestDbError` would otherwise fail under `-D warnings` (and we want to avoid `#[allow(dead_code)]`).
- Bump `actions/checkout` to `v6` in both workflows (resolves the Node 20 deprecation warning).

## Test plan
- [ ] All four matrix jobs (`clippy/test` x `debug/release`) pass on this PR
- [ ] CodeQL no longer flags either workflow