### PR TITLE
Treat warnings as errors and parallelize clippy/test jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛠 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🚀 Publish Crate
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   test:
-    name: 🧪 Test (${{ matrix.profile }})
+    name: 🧪 ${{ matrix.task }} (${{ matrix.profile }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -17,19 +17,20 @@ jobs:
         profile:
           - debug
           - release
+        task:
+          - clippy
+          - test
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - name: 🛠 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Install cargo-hack
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
 
-      - name: 📦 Cargo clippy (feature powerset)
+      - name: 📦 Cargo ${{ matrix.task }} (feature powerset)
         run: |
-          cargo hack clippy --feature-powerset ${{ matrix.profile == 'release' && '--release' || '' }} -- -D warnings
-
-      - name: 🧪 Cargo test (feature powerset)
-        run: |
-          cargo hack test --feature-powerset ${{ matrix.profile == 'release' && '--release' || '' }}
+          cargo hack ${{ matrix.task }} --feature-powerset ${{ matrix.profile == 'release' && '--release' || '' }}

--- a/tests/v1beta1_values_bad.rs
+++ b/tests/v1beta1_values_bad.rs
@@ -1,4 +1,3 @@
-mod fake_db;
 mod utils;
 
 use anyhow::Result;

--- a/tests/v1beta2_values_bad.rs
+++ b/tests/v1beta2_values_bad.rs
@@ -1,4 +1,3 @@
-mod fake_db;
 mod utils;
 
 use anyhow::Result;


### PR DESCRIPTION
## Summary
- Set `RUSTFLAGS=-D warnings` in the test workflow so any rustc or clippy warning fails CI. With that, the explicit `-- -D warnings` clippy suffix is no longer needed; a single matrix step runs `cargo hack ${{ matrix.task }} --feature-powerset [...]`.
- Expand the test matrix to `{profile} x {task}` so clippy and test runs execute as 4 parallel jobs instead of serializing within one.
- Drop unused `mod fake_db;` from `tests/v1beta{1,2}_values_bad.rs` — the dead_code warnings on `TestDb`/`TestDbError` would otherwise fail under `-D warnings`, and we want to avoid `#[allow(dead_code)]`.
- Bump `actions/checkout` to `v6` in both workflows (resolves the Node 20 deprecation warning).

## Test plan
- [ ] All four matrix jobs (`clippy/test` × `debug/release`) pass on this PR