### PR TITLE
Switch crates.io publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,18 @@ jobs:
     name: 🚀 Publish to crates.io
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: 🛠 Checkout
         uses: actions/checkout@v4
 
+      - name: 🔐 Authenticate to crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: 🚀 Publish Crate
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           cargo publish


### PR DESCRIPTION
## Summary
- Replace the long-lived `CARGO_REGISTRY_TOKEN` secret with a short-lived token minted via [`rust-lang/crates-io-auth-action`](https://github.com/rust-lang/crates-io-auth-action).
- Grant the publish job `id-token: write` so it can request a GitHub OIDC token to exchange with crates.io.

## Follow-up (post-merge)
1. Configure the Trusted Publisher on crates.io for this crate:
   - Repository owner: `platzio`
   - Repository name: `chart-ext`
   - Workflow filename: `release.yml`
   - Environment: *(none)*
2. After the first successful release via trusted publishing, delete the `CARGO_REGISTRY_TOKEN` repo secret and revoke the corresponding token on crates.io.

## Test plan
- [ ] Configure the trusted publisher on crates.io before the next tag push.
- [ ] Push a release tag and confirm the `🚀 Publish to crates.io` job authenticates and publishes successfully.