### PR TITLE
Add cargo fmt check to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,19 @@ permissions:
   contents: read
 
 jobs:
+  fmt:
+    name: 🎨 Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛠 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🧰 Install rustfmt
+        run: rustup component add rustfmt
+
+      - name: 🎨 Cargo fmt
+        run: cargo fmt --all -- --check
+
   test:
     name: 🧪 ${{ matrix.task }} (${{ matrix.profile }})
     runs-on: ubuntu-latest

--- a/src/ext_type.rs
+++ b/src/ext_type.rs
@@ -143,7 +143,7 @@ where
     T: Serialize + DeserializeOwned,
 {
     let Some(filename) = filename else {
-        return Ok(None)
+        return Ok(None);
     };
 
     let full_path = path.join(filename);


### PR DESCRIPTION
## Summary
- New `fmt` job in `.github/workflows/test.yml` runs `cargo fmt --all -- --check`, matching the formatting gate in platzio/backend
- Reformats one pre-existing trailing-semicolon diff in `src/ext_type.rs` so the new check is green on `main`'s state

## Test plan
- [ ] `fmt` job runs and passes on this PR
- [ ] Existing `clippy` / `test` matrix still runs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)